### PR TITLE
fix: add formly module to imports

### DIFF
--- a/src/app/shared/ui-formly/formly/formly-ui.module.ts
+++ b/src/app/shared/ui-formly/formly/formly-ui.module.ts
@@ -7,7 +7,7 @@ import { FormlyNgSelectTypeModule } from './formly-float-select/formly-ng-select
 
 @NgModule({
     declarations: [],
-    imports: [CommonModule, ReactiveFormsModule, FormlyNgSelectTypeModule],
+    imports: [CommonModule, ReactiveFormsModule, FormlyModule, FormlyNgSelectTypeModule],
     exports: [ReactiveFormsModule, FormlyModule, FormlyNgSelectTypeModule]
 })
 export class FormlyUiModule {}


### PR DESCRIPTION
## Summary
- add FormlyModule to FormlyUiModule imports

## Testing
- `npm test` *(fails: sh: 1: ng: not found)*
- `npm run lint` *(fails: sh: 1: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a72cb45c7c83288b22ef15ea8cf762