### PR TITLE
feat: import ng-select theme globally

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,1 +1,3 @@
+@import "~@ng-select/ng-select/themes/default.theme.css";
+
 /* You can add global styles to this file, and also import other style files */


### PR DESCRIPTION
## Summary
- add default ng-select theme to global stylesheet
- confirm styles.scss already referenced in angular.json

## Testing
- `npm ci` *(fails: 403 Forbidden - GET http://repo.vsk.ru/repository/registry.npmjs.org/make-fetch-happen)*
- `npm test` *(fails: sh: 1: ng: not found)*
- `npm run lint` *(fails: sh: 1: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a72cb1160883289b86f5de6feadfe0