### PR TITLE
fix: remove noop animations module

### DIFF
--- a/src/app/insured-events.module.ts
+++ b/src/app/insured-events.module.ts
@@ -1,9 +1,6 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import {
-    BrowserAnimationsModule,
-    NoopAnimationsModule
-} from '@angular/platform-browser/animations';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { InsuredEventsModule } from './features/insured-events/insured-events.module';
 import { InsuredEventsComponent } from './insured-events.component';
@@ -15,8 +12,7 @@ import { InsuredEventsRoutingModule } from './insured-events-routing.module';
         BrowserModule,
         InsuredEventsRoutingModule,
         InsuredEventsModule,
-        BrowserAnimationsModule,
-        NoopAnimationsModule
+        BrowserAnimationsModule
     ],
     bootstrap: [InsuredEventsComponent]
 })


### PR DESCRIPTION
## Summary
- remove NoopAnimationsModule and rely on BrowserAnimationsModule

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` (fails: ng: not found)
- `npm run build` (fails: ng: not found)


------
https://chatgpt.com/codex/tasks/task_e_68a72cb7427c8328a61d25ee9f23cc8b